### PR TITLE
Add Travis CI config and fix remaining test failure 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ develop-eggs/
 eggs/
 parts/
 sql/
+build/
+dist/
 
 # ignore settings files:
 ts/settings/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *~
 .DS_Store
+.*.swp
 
 # ignore buildout's workspace stuff:
 .installed.cfg
@@ -32,3 +33,6 @@ ts/apps/tradeschool/fixtures/migration.json
 
 # ignore branch template files (for now)
 ts/apps/branches/
+
+# ignore dev database
+dev-database.sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
 install: "./dev/setup_dev.sh"
 # command to run tests
 script: "./bin/django test tradeschool"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+install: "./dev/setup_dev.sh"
+# command to run tests
+script: "./bin/django test tradeschool"
+

--- a/README.md
+++ b/README.md
@@ -14,19 +14,16 @@ When installing locally, use development.cfg. Otherwise, fab is used to install 
 
 To install locally:
 
-1. $ python bootstrap.py -c development.cfg
-2. $ ./bin/buildout -c development.cfg
-3. edit settings/development.py with database info and local paths
-4. $ ./bin/django syncdb
-5. $ ./bin/django migrate
-6. $ ./bin/django loaddata email_initial_data.json pages_initial_data.json group_initial_data.json language_initial_data.json teacher-info.json
-7. (optional) ./bin/django loaddata sample_data.json
+    ./dev/setup_dev.sh
+
 
 To run locally:
-$ ./bin/django runserver
 
-To test:
-$ ./bin/django test tradeschool -v 2
+    ./bin/django runserver
+
+To run tests:
+
+    ./bin/django test tradeschool -v 2
 
 
 To install remotely:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Trade School Everywhere ##
 
+[![Travis Build Status](https://travis-ci.org/orzubalsky/tradeschool.svg?branch=master)](https://travis-ci.org/orzubalsky/tradeschool)
+
 
 ### Installation ###
 

--- a/base.cfg
+++ b/base.cfg
@@ -22,6 +22,8 @@ eggs =
     django-debug-toolbar
     django-tastypie
     django_ace
+    icalendar
+    polib
 parts =
 	django
 	django-mailer	
@@ -34,12 +36,15 @@ parts =
 versions = versions
 
 [versions]
-django = 1.5.1
+django=1.5.1
+django-countries=2.1
 django-grappelli=2.4.8
 django-mptt=0.5.1
 gettext=0.18.2
 MySQL-python=1.2.3
 django-tastypie=0.9.16
+icalendar=3.6.1
+polib=1.0.4
 
 [django]
 recipe = djangorecipe

--- a/base.cfg
+++ b/base.cfg
@@ -22,7 +22,6 @@ eggs =
     django-debug-toolbar
     django-tastypie
     django_ace
-    icalendar
     polib
 parts =
 	django
@@ -43,7 +42,6 @@ django-mptt=0.5.1
 gettext=0.18.2
 MySQL-python=1.2.3
 django-tastypie=0.9.16
-icalendar=3.6.1
 polib=1.0.4
 
 [django]

--- a/dev/setup_dev.sh
+++ b/dev/setup_dev.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Setup your build environment for the first time.
+#
+# Download dependencies, move dev config into place, create and load the
+# database with some sample data.
+
+set -e
+set -x
+
+
+python bootstrap.py -c development.cfg
+./bin/buildout -c development.cfg
+cp ts/settings/development.py.template ts/settings/development.py
+
+secret_key=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = '$secret_key'/" ts/settings/development.py
+
+./bin/django syncdb
+./bin/django migrate
+./bin/django loaddata email_initial_data.json \
+        pages_initial_data.json \
+        group_initial_data.json \
+        language_initial_data.json \
+        teacher-info.json
+
+./bin/django loaddata sample_data.json
+
+set +x
+echo "
+
+To run locally:
+$ ./bin/django runserver
+
+To run tests:
+$ ./bin/django test tradeschool -v 2
+
+"

--- a/ts/apps/tradeschool/middleware.py
+++ b/ts/apps/tradeschool/middleware.py
@@ -1,12 +1,12 @@
-import ast
 from django.utils import timezone, translation
 from django.core.urlresolvers import resolve
+import simplejson
+
 from tradeschool.models import *
 
 
 class BranchMiddleware(object):
     def process_request(self, request):
-
         try:
             url = resolve(request.path)
 
@@ -19,10 +19,7 @@ class BranchMiddleware(object):
                request.method == 'POST' and
                request.is_ajax()):
 
-                # the incoming data from Dajaxice looks like
-                # a Python dictionary, but it's a string.
-                # We're parsing it using the ast library
-                ajax_dict = ast.literal_eval(request.POST.dict()['argv'])
+                ajax_dict = simplejson.loads(request.POST.dict()['argv'])
 
                 # after that we can get the branch_slug value,
                 # like from any other dictionary

--- a/ts/apps/tradeschool/models.py
+++ b/ts/apps/tradeschool/models.py
@@ -21,7 +21,7 @@ from django.core.mail import EmailMessage
 #from django_mailer import send_mail
 from django.template import Context
 from django.template import Template
-from django_countries import CountryField
+from django_countries.fields import CountryField
 from tinymce.models import HTMLField
 from datetime import *
 from tradeschool.utils import copy_model_instance, unique_slugify

--- a/ts/apps/tradeschool/tests/branch.py
+++ b/ts/apps/tradeschool/tests/branch.py
@@ -215,15 +215,6 @@ class BranchTestCase(TestCase):
             branch.language = language_code
             branch.save()
 
-            # it's not possible to use translation.activate
-            # in the context of a unittest-
-            # what happens is that once a get/post request is made,
-            # django calls translation.activate with the language
-            # that's defined in settings (or the testcase's settings override).
-            # This means we can't really test the language switching
-            # unless we override the settings.
-            settings.LANGUAGE_CODE = language_code
-
             # load a page to check the language setting
             response = self.client.get(url)
 

--- a/ts/apps/tradeschool/tests/branch.py
+++ b/ts/apps/tradeschool/tests/branch.py
@@ -227,17 +227,9 @@ class BranchTestCase(TestCase):
             # load a page to check the language setting
             response = self.client.get(url)
 
-            # verify the languages match. test in 2 parts,
-            # since the language codes don't really match-
-            # they're both es_es and es-es.
             self.assertEqual(
-                branch.language[:2],
-                response.context['LANGUAGE_CODE'][:2]
-            )
-
-            self.assertEqual(
-                branch.language[3:],
-                response.context['LANGUAGE_CODE'][3:]
+                branch.language.lower(),
+                response.context['LANGUAGE_CODE']
             )
 
     def test_branch_timezone(self):

--- a/ts/apps/tradeschool/tests/email.py
+++ b/ts/apps/tradeschool/tests/email.py
@@ -83,7 +83,10 @@ class EmailTestCase(TestCase):
         """ Compares the data from the email message in the mail outbox
             and the Email object.
         """
-        self.assertEqual(message_obj.from_email, self.branch.email)
+        self.assertEqual(
+            message_obj.extra_headers['Reply-To'],
+            self.branch.email
+        )
         self.assertEqual(message_obj.subject, email_obj.subject)
         self.assertEqual(
             message_obj.body,

--- a/ts/settings/development.py.template
+++ b/ts/settings/development.py.template
@@ -21,10 +21,10 @@ TEMPLATE_DEBUG = DEBUG
 DATABASES = {
     'default': {
         # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': 'django.db.backends.sqlite3',
 
         # Or path to database file if using sqlite3.
-        'NAME': '',
+        'NAME': 'dev-database.sqlite3',
 
         # Not used with sqlite3.
         'USER': '',


### PR DESCRIPTION
Hello,

This is another branch off of #145. This branch adds a `.travis.yml` for running the test suite on Travis CI. This is really nice because it lets you see if pull requests break your tests without having to merge and run the tests yourself locally (travis CI will monitor pull requests and pushes to branches and run the test suite each time). 

It also ensures that the build is explicit about all dependencies (because if anything was missing it would fail to run the tests).

I've verified the config works by setting it up on my branch, but I think we want it on the main repo (your account).  To get it setup for your repo you'll have to follow steps 1 and 2 here:
http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in

I've also added the badge to the README, so we can see if the test suite is green right from github.

This branch also includes two other small changes:
1. I fixed the broken test (using `lower()`, and removed `settings.LANGUAGE_CODE = language_code`. I believe by setting the `LANGUAGE_CODE` we aren't actually testing the middleware because it would already default to that language. The tests still passed with that line removed
2. I changed the middleware to use `simplejson.loads()` instead of ast.  I believe the string you are parsing is actually a json string (since this is an ajax request).  Although the ast parsing worked, I believe that is just a coincidence because python dicts look basically the same as json objects.
