### PR TITLE
Allow admins to edit is_active of an organizer

### DIFF
--- a/ts/apps/tradeschool/admin.py
+++ b/ts/apps/tradeschool/admin.py
@@ -1147,6 +1147,7 @@ class OrganizerAdmin(PersonAdmin):
         'is_student',
         'is_teacher',
         'is_staff',
+        'is_active',
         'bio',
         'default_branch',
         'branches',


### PR DESCRIPTION
Initial solution for #148

Organizers are being created with `is_active=False` when they signup to create a new branch. This pull request adds  `is_active` field to admin so that  admins can set organizers as active from admin after the branch is approved (this would also allows admins to deactivate organizers).

There may be a way to automate this so that changing from pending to starting of a branch will change the `is_active` to True automatically. Or we might want to just create the account as active by default.

Let me know what you think!
