### PR TITLE
Fix available class times on course add view

### DIFF
--- a/ts/apps/tradeschool/forms.py
+++ b/ts/apps/tradeschool/forms.py
@@ -53,9 +53,9 @@ class TimeSelectionForm(forms.Form):
     def __init__(self, branch, **kwargs):
         super(TimeSelectionForm, self).__init__(**kwargs)
         self.fields['time'].queryset = Time.objects.filter(
-                branch=branch,
-                is_active=True,
-                start_time__gt=datetime.datetime.now())
+            branch=branch,
+            is_active=True,
+            start_time__gt=datetime.datetime.now())
 
     time = TimeModelChoiceField(
         queryset=None,
@@ -120,7 +120,8 @@ class OrganizerForm(TeacherForm):
         self.fields['names_of_co_organizers'].error_messages['required'] = _(
             "Please enter the names of at least one or two more organizers")
         self.fields['bio'].error_messages['required'] = _(
-            "Please tell us about why you would like to open a Trade School in your area")
+            "Please tell us about why you would like to open a Trade School "
+            "in your area")
 
     class Meta:
         model = Person
@@ -139,7 +140,8 @@ class OrganizerForm(TeacherForm):
     )
     bio = forms.CharField(
         required=True,
-        label=_("A few sentences about why your group wants to open a Trade School"),
+        label=_("A few sentences about why your group wants to open a "
+                "Trade School"),
         widget=forms.Textarea
     )
 

--- a/ts/apps/tradeschool/forms.py
+++ b/ts/apps/tradeschool/forms.py
@@ -52,10 +52,11 @@ class TimeSelectionForm(forms.Form):
     """
     def __init__(self, branch, **kwargs):
         super(TimeSelectionForm, self).__init__(**kwargs)
+        now = datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
         self.fields['time'].queryset = Time.objects.filter(
             branch=branch,
             is_active=True,
-            start_time__gt=datetime.datetime.now())
+            start_time__gt=now)
 
     time = TimeModelChoiceField(
         queryset=None,

--- a/ts/apps/tradeschool/forms.py
+++ b/ts/apps/tradeschool/forms.py
@@ -48,7 +48,7 @@ class TimeModelChoiceField(forms.ModelChoiceField):
 class TimeSelectionForm(forms.Form):
     """
     A simple dropdown menu for teachers to select an available time
-    when submitting a class. Constrcuted from a Branch and uses the Time model.
+    when submitting a class. Constructed from a Branch and uses the Time model.
     """
     def __init__(self, branch, **kwargs):
         super(TimeSelectionForm, self).__init__(**kwargs)

--- a/ts/apps/tradeschool/tests/course.py
+++ b/ts/apps/tradeschool/tests/course.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from django.contrib.sites.models import Site
 from django.conf import settings
 from django.utils import timezone
-from datetime import *
+from datetime import datetime, timedelta
 from tradeschool.models import *
 
 
@@ -319,7 +319,7 @@ class CourseTestCase(TestCase):
             'venue': self.branch.venue_set.all()[0].pk
         }
 
-        response = self.client.post(url, data=data, follow=True)
+        self.client.post(url, data=data, follow=True)
 
         # verify a new timerange was saved
         current_timerange_count = TimeRange.objects.all().count()
@@ -511,8 +511,7 @@ class CourseTestCase(TestCase):
         time = Time.objects.get(pk=self.time_data['time-time'])
 
         # post the data to the course submission form
-        response = self.client.post(
-            self.url, data=self.valid_data, follow=True)
+        self.client.post(self.url, data=self.valid_data, follow=True)
 
         # check that the time object got deleted
         self.assertFalse(Time.objects.filter(pk=time.pk).exists())
@@ -725,7 +724,6 @@ class CourseTestCase(TestCase):
         course_list_url = reverse(
             'course-list', kwargs={'branch_slug': branch.slug})
         response = self.client.get(course_list_url)
-        #self.assertNotContains(response, 'Past') NOTE: not implemented yet -Or
 
         # past courses url
         url = reverse(
@@ -773,6 +771,6 @@ class CourseTestCase(TestCase):
 def build_time(branch, start_time):
     one_hour = timedelta(hours=1)
     return Time(
-            branch=branch,
-            start_time=start_time,
-            end_time=start_time + one_hour)
+        branch=branch,
+        start_time=start_time,
+        end_time=start_time + one_hour)

--- a/ts/apps/tradeschool/views.py
+++ b/ts/apps/tradeschool/views.py
@@ -232,19 +232,16 @@ def course_add(request, branch_slug=None):
     if request.method == 'POST':
         BarterItemFormSet = formset_factory(
             BarterItemForm, extra=5, formset=BaseBarterItemFormSet)
-        barter_item_formset = BarterItemFormSet(data=request.POST, prefix="item", branch=branch)
+        barter_item_formset = BarterItemFormSet(
+            data=request.POST, prefix="item", branch=branch)
         course_form = CourseForm(request.POST, prefix="course")
         teacher_form = TeacherForm(request.POST, prefix="teacher")
-        time_form = TimeSelectionForm(
-            data=request.POST,
-            prefix="time",
-        )
-        time_form.fields['time'].queryset = Time.objects.filter(branch=branch)
+        time_form = TimeSelectionForm(branch, data=request.POST, prefix="time")
 
-        if barter_item_formset.is_valid() \
-                and course_form.is_valid() \
-                and teacher_form.is_valid() \
-                and time_form.is_valid():
+        if all([barter_item_formset.is_valid(),
+                course_form.is_valid(),
+                teacher_form.is_valid(),
+                time_form.is_valid()]):
             # process teacher
             teacher = teacher_form.save(commit=False)
             teacher_data = teacher_form.cleaned_data
@@ -343,8 +340,7 @@ def course_add(request, branch_slug=None):
         barter_item_formset = BarterItemFormSet(prefix="item", branch=branch)
         course_form = CourseForm(prefix="course")
         teacher_form = TeacherForm(prefix="teacher")
-        time_form = TimeSelectionForm(prefix="time")
-        time_form.fields['time'].queryset = Time.objects.filter(branch=branch)
+        time_form = TimeSelectionForm(branch, prefix="time")
 
     view_templates = branch_templates(
         branch, 'course_submit.html', 'subpage.html')


### PR DESCRIPTION
Resolves #151

I've modified the `TimeSelectionForm` to accept a branch and use a default queryset which filters to only active courses in the future. I also added a test for this first (so I could verify that it was failing).

The other changes are largely just to get the code passing in [flake8](https://flake8.readthedocs.org/en/2.0/). flake8 can be great for catching unused variables and helps keep the code consistent with common python code style. Once more files are passing we can add it as part of the travis run.
